### PR TITLE
Fix resources other than image

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -118,7 +118,7 @@ func HandlingCoreBusiness(progress chan<- int,  done chan<- bool) {
 
 func FixResourceRef(article *Article, resMap *map[string]*Resource) {
 	content := article.content
-	r, _ := regexp.Compile(`!\[(.*?)]\(:/(.*?)\)`)
+	r, _ := regexp.Compile(`!?\[(.*?)]\(:/(.*?)\)`)
 	matchAll := r.FindAllStringSubmatchIndex(content, -1)
 	for i:=len(matchAll)-1;i>=0;i-- {
 		match := matchAll[i]


### PR DESCRIPTION
The `!` should not be mandatory.  Internal resources can be more than images, it can be any files. By removing the `!` it will fix the reference for all internal files.