### PR TITLE
Changed name of "resources" directory

### DIFF
--- a/def.go
+++ b/def.go
@@ -11,7 +11,7 @@ import (
 var SrcPath *string
 var DestPath *string
 
-const ResourcesFolder string = "resources"
+const ResourcesFolder string = ".resource"
 
 func CheckError(e error) {
 	if e != nil {
@@ -88,7 +88,7 @@ func (r Resource) getFileName() string {
 	if /*len(r.metaFileExt) > 0*/ false {
 		fileName = fmt.Sprintf("%s.%s", r.metaId, r.metaFileExt)
 	} else {
-		resPath := path.Join(*SrcPath, "resources")
+		resPath := path.Join(*SrcPath, ".resource")
 		c, err := ioutil.ReadDir(resPath)
 		CheckError(err)
 		for _, entry := range c {


### PR DESCRIPTION
Hi,

I was trying to export notes today and got this error:

> joplin2obsidian v0.2.1-10-g2010861
> 
> ⠙ Extracting Metadata (1442/-, 9180 it/s) 
> ⠋ Rebuilding Folders (92/-, 947009 it/s) 
> panic: lstat /joplin/resources: no such file or directory
> 
> goroutine 19 [running]:
> main.CheckError(...)
>         /home/piotrek/Documents/TEMP/joplin2obsidian/joplin2obsidian/def.go:18
> main.HandlingCoreBusiness(0xc0000f2000?, 0xc0000f2070?)
>         /home/piotrek/Documents/TEMP/joplin2obsidian/joplin2obsidian/utils.go:121 +0x525
> created by main.main
>         /home/piotrek/Documents/TEMP/joplin2obsidian/joplin2obsidian/main.go:42 +0x2b8

It seems that the "resources" directory has changed its name and is now ".resource" (at least in my Joplin instance). If anyone else had the same problem, here are the changes to get it working again.