### PR TITLE
Set file modification time based on Joplin note's updated_time

### DIFF
--- a/def.go
+++ b/def.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 )
 
 var SrcPath *string
@@ -26,6 +27,7 @@ type FileInfo struct {
 	metaParentId string
 	metaType     int //1:Article 2:Folder 4:Resource 5:Tag
 	metaFileExt  string
+	updatedTime  time.Time
 }
 
 func (fi FileInfo) getValidName() string {
@@ -77,6 +79,14 @@ func (a Article) save() {
 	}
 	err := ioutil.WriteFile(filePath, []byte(a.content), 0644)
 	CheckError(err)
+	
+	// Set the file's modification time based on the Joplin note's updated_time
+	if !a.updatedTime.IsZero() {
+		err = os.Chtimes(filePath, a.updatedTime, a.updatedTime)
+		if err != nil {
+			fmt.Printf("Warning: Failed to set modification time for %s: %v\n", filePath, err)
+		}
+	}
 }
 
 type Resource struct {

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	copy2 "github.com/otiai10/copy"
 )
@@ -55,6 +56,23 @@ func GetFileInfo(filePath string) (*FileInfo, *string) {
 		metaFileExt = match[1]
 	}
 
+	// Extract updated_time from metadata
+	updatedTime := time.Time{}
+	r, _ = regexp.Compile("updated_time: *(.*)\n")
+	match = r.FindStringSubmatch(strMeta)
+	if len(match) >= 2 && match[1] != "" {
+		timestamp, err := time.Parse(time.RFC3339Nano, match[1])
+		if err == nil {
+			updatedTime = timestamp
+		} else {
+			// Try without nanoseconds if first parse fails
+			timestamp, err = time.Parse(time.RFC3339, match[1])
+			if err == nil {
+				updatedTime = timestamp
+			}
+		}
+	}
+
 	r, _ = regexp.Compile("(.*)\n")
 	match = r.FindStringSubmatch(strData)
 	if len(match) < 2 {
@@ -69,6 +87,7 @@ func GetFileInfo(filePath string) (*FileInfo, *string) {
 		metaType:     metaType,
 		metaParentId: metaParentId,
 		metaFileExt:  metaFileExt,
+		updatedTime:  updatedTime,
 	}, &strData
 }
 


### PR DESCRIPTION
This change extracts the `updated_time` field from Joplin note metadata and sets the corresponding markdown file's modification time accordingly.